### PR TITLE
support open files relative to script url parameter

### DIFF
--- a/ports/javascript/docs/wasm_file_api.js
+++ b/ports/javascript/docs/wasm_file_api.js
@@ -86,9 +86,18 @@ function wasm_file_open(url, cachefile){
     }
 
     try {
-        if (url[0]==":")
-            url = url.substr(1)
-        else {
+        if (url[0]==":"){
+            url = url.substr(1);
+        } else if(url.indexOf(":") == -1){ // no ":" - might be path relative to script
+            let external_path = new URL(window.top.location.href).searchParams.get("script");
+            if(external_path !== undefined && external_path !== null){
+                url = new URL(url, external_path).href;
+                console.log(url);
+                if(window.urls.cors){
+                    url = window.urls.cors(url);
+                }
+            }
+        } else {
             // [TODO:do some tests there for your CORS integration]
             if (window.urls.cors)
                 url = window.urls.cors(url)

--- a/ports/javascript/modules/imp.py
+++ b/ports/javascript/modules/imp.py
@@ -21,7 +21,7 @@ def importer(name, *argv, **kw):
         pass
 
     filen = ':{0}.py'.format(name)
-    print("INFO: getting online local version of", filen, file=sys.stderr)
+    # print("INFO: getting online local version of", filen, file=sys.stderr)
     # todo open the file via open() or raise importerror
     try:
         code = open(filen, 'r').read()
@@ -30,7 +30,7 @@ def importer(name, *argv, **kw):
         for i, path_url in enumerate(sys.path):
             if path_url.startswith('http://') or path_url.startswith('https://'):
                 filen = '{0}/{1}.py'.format(path_url, name)
-                print("INFO: try to get online remote version of", filen, file=sys.stderr)
+                # print("INFO: try to get online remote version of", filen, file=sys.stderr)
                 try:
                     code = open(filen, 'r').read()
                     remote = True
@@ -60,7 +60,7 @@ def importer(name, *argv, **kw):
     try:
         ns = vars(mod)
     except:
-        print("WARNING: this python implementation lacks vars()", file=sys.stderr)
+        # print("WARNING: this python implementation lacks vars()", file=sys.stderr)
         ns = mod.__dict__
 
     try:

--- a/ports/javascript/wasm_file_api.c
+++ b/ports/javascript/wasm_file_api.c
@@ -12,21 +12,29 @@ wasm_file_open(const char *url) {
     fprintf(stderr,"10:wasm_file_open[%s]\n", url);
 
     if (strlen(url)>1 && url[0]==':') {
+        // same domain file - starts with :
         fprintf(stderr,"  -> same host[%s]\n", url);
         int fidx = EM_ASM_INT({return wasm_file_open(UTF8ToString($0)); }, url );
 
         // TODO rebuild local path in ramdisk relative to getcwd()
         char fname[MICROPY_ALLOC_PATH_MAX];
-
         snprintf(fname, sizeof(fname), "cache_%d", fidx);
         return fileno( fopen(fname,"r") );
-    }
-    if ( (strlen(url)>6) && (url[4]==':' || url[5]==':') ) {
+    }else if ( (strlen(url)>6) && (url[4]==':' || url[5]==':') ) {
+        // url: http(s)://...
         fprintf(stderr,"  -> remote host[%s]\n", url);
         int fidx = EM_ASM_INT({return wasm_file_open(UTF8ToString($0)); }, url );
         char fname[20];
         snprintf(fname, sizeof(fname), "cache_%d", fidx);
         return fileno( fopen(fname,"r") );
+    } else {
+        // file with no ':' - might be in the script folder
+        int fidx = EM_ASM_INT({return wasm_file_open(UTF8ToString($0)); }, url );
+        if(fidx != -1){
+            char fname[MICROPY_ALLOC_PATH_MAX];
+            snprintf(fname, sizeof(fname), "cache_%d", fidx);
+            return fileno( fopen(fname,"r") );
+        }
     }
     return 0;
 }


### PR DESCRIPTION
If `script=...` parameter is provided to the editor, the simulator will try to open resources with the same path.
Example:
https://stepansnigirev.github.io/sim/?script_startup=https://gist.githubusercontent.com/stepansnigirev/d360caaca643a17989b1b41ceef417d1/raw/init_script.py&script=https://gist.githubusercontent.com/stepansnigirev/87032c693fd12eeb9dfd219535630691/raw/page.py

This page is loading the license content from the file stored in the same gist.

I also commented out print statements in `imp.py` as in my build I had an error that `sys.stderr` is not available.